### PR TITLE
FIX: single char string method call deduct error.

### DIFF
--- a/lib/src/main/cpp/java_type.cpp
+++ b/lib/src/main/cpp/java_type.cpp
@@ -258,6 +258,9 @@ const MethodInfo *JavaType::deductMethod(TJNIEnv* env,const MethodArray* array, 
                     if (provided == nullptr) {
                         if (strlen8to16(luaObject.string) == 1){
                             switch(toCheck->getTypeID()){
+                                case OBJECT:
+                                    cacheScores[i]=10;
+                                    break;
                                 case CHAR:
                                     cacheScores[i]=9;
                                     break;

--- a/luadroidtest/src/main/assets/deduct.lua
+++ b/luadroidtest/src/main/assets/deduct.lua
@@ -1,0 +1,3 @@
+import 'com.oslorde.luadroidtest.DeductTest'
+
+assert(DeductTest.string("a"))

--- a/luadroidtest/src/main/java/com/oslorde/luadroidtest/DeductTest.java
+++ b/luadroidtest/src/main/java/com/oslorde/luadroidtest/DeductTest.java
@@ -1,0 +1,12 @@
+package com.oslorde.luadroidtest;
+
+/**
+ * @author weishu
+ * @date 2019-09-27.
+ */
+public class DeductTest {
+
+    public static Object string(String str) {
+        return str;
+    }
+}

--- a/luadroidtest/src/main/java/com/oslorde/luadroidtest/MainActivity.java
+++ b/luadroidtest/src/main/java/com/oslorde/luadroidtest/MainActivity.java
@@ -64,6 +64,7 @@ public class MainActivity extends AppCompatActivity {
 
     void test(){
         compilerTest();
+        deductTest();
     }
 
     private static byte[] readAllBytes(InputStream in) throws IOException {
@@ -198,6 +199,18 @@ public class MainActivity extends AppCompatActivity {
         }
     }
 
+    public void deductTest() {
+        ScriptContext context=new ScriptContext();
+        AssetManager manager=getAssets();
+        try(InputStream stream=manager.open("deduct.lua")) {
+            context.run(readAll(stream));
+        }catch (Exception e){
+            context.flushLog();
+            Log.e("deduct","Test failed",e);
+        }
+        context.flushLog();
+        Log.d("deduct","Test passed");
+    }
 
     public void ffitest() {
         // Context of the app under test.


### PR DESCRIPTION
If i want to call a method with string parameters, such as:

```java
public class DeductTest {
    public static void string(String param) {}
}
```
and i call it in lua:

```lua
Deduct.string("a")
```

this would throw an NosuchMethodException, because it force single char string to char.

this PR should fix this.